### PR TITLE
Resolving issue with 'shard_count' output when stream_mode is 'ON_DEMAND'

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=%!!(string=docs)s(<nil>)&utm_content=%!s(MISSING)
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=%!!(string=website)s(<nil>)&utm_content=%!s(MISSING)
@@ -405,3 +405,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/%!s(<nil>)
   [share_email]: mailto:?subject=terraform-aws-kinesis-stream&body=https://github.com/%!s(<nil>)
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/%!s(<nil>)?pixel&cs=github&cm=readme&an=nil
+<!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "name" {
 
 output "shard_count" {
   description = "Number of shards provisioned."
-  value       = join("", aws_kinesis_stream.default.*.shard_count)
+  value       = try(aws_kinesis_stream.default[0].shard_count, null)
 }
 
 output "stream_arn" {


### PR DESCRIPTION
## what & why

* The `join` used by the `shard_count` output fails when `stream_mode` is set to `ON_DEMAND` because the value is `null`
* Using a simple `try` instead resolves the issue.

